### PR TITLE
Fixed a typo in Lab2 of W26 course Geog 3420

### DIFF
--- a/Courses/W26/GEOG3420/Lab2/part3.html
+++ b/Courses/W26/GEOG3420/Lab2/part3.html
@@ -199,7 +199,7 @@
 <p>where ρ is the transformed reflectance value (at wavelength, λ), <em>M</em> is the band-specific multiplicative rescaling factor, and <em>A</em> is the band-specific additive rescaling factor. <em>M</em> and <em>A</em> can each be found within the metadata file distributed with a Landsat scene.</p>
 <p>Open the metadata file associated with the lab data, <code>LC09_L2SP_018030_20220614_20220616_02_T1_MTL.txt</code>, using a text editor (e.g. Notepad, VS Code, etc.). Locate each the reflectance rescaling parameters (e.g. REFLECTANCE_MULT_BAND_1, REFLECTANCE_ADD_BAND_1, etc.) in the file.</p>
 <p>We could use Eq. 1 above to convert each of the bands within our scene data set manually. However, this would be a tedious task and the opportunities for using the incorrect parameter by accident is fairly high. Instead, we're going to write a script to automatically read the parameters from the metadata file and then apply the DN-to-reflectance transform to each of our bands. Using <em>VS Code</em>, create a Python script in your Lab 2 folder called <code>reflectance.py</code>. Copy the following code into your script file and run it.</p>
-<p><em>relectance.py</em></p>
+<p><em>reflectance.py</em></p>
 <pre><code class="language-python">import os
 import whitebox_workflows
 


### PR DESCRIPTION
Changed relectance.py to reflectance.py  in Lab2 part3 of W26. It was annoying me :)